### PR TITLE
Remove spaces from NSGSec Rule Names

### DIFF
--- a/terraform/mssql-server/main.tf
+++ b/terraform/mssql-server/main.tf
@@ -67,7 +67,7 @@ resource "azurerm_public_ip" "windows" {
 }
 
 resource "azurerm_network_security_rule" "rdp" {
-  name                        = "Allow RDP"
+  name                        = "Allow_RDP"
   priority                   = 200
   direction                  = "Inbound"
   access                     = "Allow"
@@ -81,7 +81,7 @@ resource "azurerm_network_security_rule" "rdp" {
 }
 
 resource "azurerm_network_security_rule" "ping" {
-  name                        = "Allow ICMP pings"
+  name                        = "Allow_ICMP_pings"
   priority                   = 202
   direction                  = "Inbound"
   access                     = "Allow"

--- a/terraform/vault-server/main.tf
+++ b/terraform/vault-server/main.tf
@@ -81,7 +81,7 @@ resource "azurerm_network_security_rule" "ssh_port" {
 }
 
 resource "azurerm_network_security_rule" "vault_port" {
-  name                        = "Vault API"
+  name                        = "Vault_API"
   priority                    = 101
   direction                   = "Inbound"
   access                      = "Allow"


### PR DESCRIPTION
replaced spaces with underscores after receiving the following errors for all security rules with spaces in names.

```
Error: creating/updating Security Rule: (Name "Vault API" / Network Security Group Name "example-nsg" / Resource Group "example-rg"): network.SecurityRulesClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidResourceName" Message="Resource name Vault API is invalid. The name can be up to 80 characters long. It must begin with a word character, and it must end with a word character or with '_'. The name may contain word characters or '.', '-', '_'." Details=[]
│ 
│   with module.vault-server.azurerm_network_security_rule.vault_port,
│   on vault-server/main.tf line 83, in resource "azurerm_network_security_rule" "vault_port":
│   83: resource "azurerm_network_security_rule" "vault_port" {

```