### PR TITLE
add overwrite flag to vault unzip

### DIFF
--- a/terraform/templates/deploy-vault-instance.bash
+++ b/terraform/templates/deploy-vault-instance.bash
@@ -28,7 +28,7 @@ curl \
 
 ls -l
 
-unzip vault_${VAULT_VERSION}_linux_amd64.zip
+unzip -o vault_${VAULT_VERSION}_linux_amd64.zip
 
 sudo chown root:root vault
 sudo mv vault /usr/local/bin/


### PR DESCRIPTION
Null provisioner seems to be hanging on waiting on user input to replace EULA.txt file.  Added `unzip -o ` flag to overwrite existing files.

```
module.vault-server.null_resource.deploy-vault-instance (remote-exec): -rw-rw-r-- 1 vadmin vadmin 75266830 Feb 22 00:06 vault_1.10.4+ent_linux_amd64.zip
module.vault-server.null_resource.deploy-vault-instance (remote-exec): Archive:  vault_1.10.4+ent_linux_amd64.zip
module.vault-server.null_resource.deploy-vault-instance (remote-exec): replace EULA.txt? [y]es, [n]o, [A]ll, [N]one, [r]ename:
```
